### PR TITLE
chore(dependencies): remove lodash's pre-method packages

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,8 @@
 /* eslint-disable vars-on-top, no-var, prefer-template */
-var isRegExp = require('lodash.isregexp');
-var escapeRegExp = require('lodash.escaperegexp');
-var isString = require('lodash.isstring');
-var flatten = require('lodash.flatten');
+var isRegExp = require('lodash/isRegExp');
+var escapeRegExp = require('lodash/escapeRegExp');
+var isString = require('lodash/isString');
+var flatten = require('lodash/flatten');
 
 /**
  * Given a string, replace every substring that is matched by the `match` regex

--- a/package.json
+++ b/package.json
@@ -31,10 +31,7 @@
     "replace"
   ],
   "dependencies": {
-    "lodash.escaperegexp": "^4.1.1",
-    "lodash.flatten": "^4.2.0",
-    "lodash.isregexp": "^4.0.1",
-    "lodash.isstring": "^4.0.1"
+    "lodash": "^4.17.4"
   },
   "devDependencies": {
     "ava": "^0.20.0",


### PR DESCRIPTION
Depending directly on lodash packages isn't supported by lodash anymore.

Close #26 