### PR TITLE
chore(types): updated ReactNode type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,9 +1,9 @@
-declare module 'react-string-replace' {
+declare module "react-string-replace" {
   function reactStringReplace(
-    text?: string | React.ReactNodeArray, 
-    regex?: string | RegExp, 
+    text?: string | React.ReactNode[],
+    regex?: string | RegExp,
     cb?: (match: string, index: number, offset: number) => React.ReactNode
-  ): React.ReactNodeArray;
+  ): React.ReactNode[];
 
   export default reactStringReplace;
 }


### PR DESCRIPTION
Hi, in this PR I've updated Typescript return tupe from function from deprecated `ReactNodeArray` to `ReactNode[]` and also first param of the function is also accepting `ReactNode[]` instead of `ReactNodeArray`